### PR TITLE
New minimal coordinator, robust connection handling, and accurate volume mapping

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -40,6 +40,9 @@
         }
     },
     "remoteUser": "vscode",
+    "remoteEnv": {
+        "GIT_EDITOR": "cursor --wait"
+    },
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
             "moby": false

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -10,6 +10,7 @@ logger:
   default: info
   logs:
     custom_components.triad_ams: debug
+    homeassistant.components.sonos: error
 
 sonos:
   media_player:

--- a/custom_components/triad_ams/connection.py
+++ b/custom_components/triad_ams/connection.py
@@ -5,13 +5,16 @@ Provides async helpers to control and query device state.
 """
 
 import asyncio
+import contextlib
 import logging
 import re
 from typing import cast
 
-from .const import INPUT_COUNT
+from .const import INPUT_COUNT, VOLUME_STEPS
+from .volume_lut import step_for_db
 
 _LOGGER = logging.getLogger(__name__)
+TRACE = 5  # Home Assistant supports 'trace' level; use numeric 5
 
 
 class TriadConnection:
@@ -28,11 +31,14 @@ class TriadConnection:
     async def connect(self) -> None:
         """Establish a connection to the Triad AMS device if not already connected."""
         if self._writer is not None:
+            _LOGGER.log(TRACE, "connect(): already connected; skipping")
             return
+        _LOGGER.log(TRACE, "connect(): begin to %s:%s", self.host, self.port)
         self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
         _LOGGER.info("Connected to Triad AMS at %s:%s", self.host, self.port)
         # Some devices need a short delay after connect before accepting commands
         await asyncio.sleep(0.2)
+        _LOGGER.log(TRACE, "connect(): ready (post-sleep)")
 
     async def disconnect(self) -> None:
         """Close the connection to the Triad AMS device if open."""
@@ -43,40 +49,97 @@ class TriadConnection:
             self._writer = None
             _LOGGER.info("Disconnected from Triad AMS")
 
-    async def _send_command(self, command: bytes) -> str:
+    def close_nowait(self) -> None:
+        """Close the transport without awaiting shutdown (non-blocking)."""
+        _LOGGER.log(
+            TRACE, "close_nowait(): writer is %s", "present" if self._writer else "None"
+        )
+        if self._writer is not None:
+            with contextlib.suppress(Exception):
+                self._writer.close()
+        self._reader = None
+        self._writer = None
+        _LOGGER.log(TRACE, "close_nowait(): cleared reader/writer")
+
+    async def _send_command(self, command: bytes, *, expect: str | None = None) -> str:
         """
         Send a command and return the response string.
 
         Adds a small inter-command delay, logs raw traffic, and applies a
         reasonable timeout to reads.
         """
+        _LOGGER.log(TRACE, "_send_command(): waiting for lock")
         async with self._lock:
+            _LOGGER.log(TRACE, "_send_command(): acquired lock")
             if self._writer is None or self._reader is None:
+                _LOGGER.log(
+                    TRACE, "_send_command(): transport missing; calling connect()"
+                )
                 await self.connect()
             # Create local non-optional references for type checkers
             writer = cast("asyncio.StreamWriter", self._writer)
             reader = cast("asyncio.StreamReader", self._reader)
             _LOGGER.debug("Sending raw bytes: %s", command.hex())
+            _LOGGER.log(TRACE, "_send_command(): writing %d bytes", len(command))
             writer.write(command)
+            _LOGGER.log(TRACE, "_send_command(): before drain()")
             await writer.drain()
-            # Add a small delay between commands for device tolerance
-            await asyncio.sleep(0.2)
-            try:
-                response = await asyncio.wait_for(reader.readuntil(b"\x00"), timeout=10)
-            except TimeoutError:
-                _LOGGER.exception(
-                    "Timeout waiting for response to command: %s", command.hex()
-                )
-                return ""
-            except asyncio.IncompleteReadError as e:
-                _LOGGER.exception(
-                    "Incomplete read waiting for response to command: %s, partial=%r",
-                    command.hex(),
-                    e.partial,
-                )
-                return e.partial.decode(errors="replace").strip()
+            _LOGGER.log(TRACE, "_send_command(): after drain()")
+            # Add a very small delay for device tolerance
+            await asyncio.sleep(0.1)
+            _LOGGER.log(TRACE, "_send_command(): awaiting response")
+            response = await asyncio.wait_for(reader.readuntil(b"\x00"), timeout=5)
+            _LOGGER.log(TRACE, "_send_command(): received %d bytes", len(response))
             _LOGGER.debug("Raw response: %r", response)
-            return response.decode(errors="replace").strip("\x00").strip()
+            text = response.decode(errors="replace").strip("\x00").strip()
+            # Evaluate the first (and only) frame. If it doesn't match the
+            # expected pattern, allow exactly one skip for an unsolicited
+            # AudioSense event, then re-evaluate the next frame.
+            if (
+                expect is not None
+                and text
+                and not re.search(expect, text, re.IGNORECASE)
+            ):
+                if re.search(
+                    r"^AudioSense:Input\[\d+\]\s*:\s*(0|1)\s*$",
+                    text,
+                    re.IGNORECASE,
+                ):
+                    _LOGGER.debug("Skipping unsolicited AudioSense event: %s", text)
+                    response = await asyncio.wait_for(
+                        reader.readuntil(b"\x00"), timeout=5
+                    )
+                    _LOGGER.debug("Raw response (post-AudioSense): %r", response)
+                    text = response.decode(errors="replace").strip("\x00").strip()
+                # After optional skip, if still not matching -> error
+                if text and not re.search(expect, text, re.IGNORECASE):
+                    _LOGGER.warning("Unexpected response: %s", text)
+                    self.close_nowait()
+                    err_msg = "Unexpected response from device"
+                    raise OSError(err_msg)
+            # Detect device-side command error or protocol desync (nulls)
+            if text == "" or re.search(r"^command\s+error$", text, re.IGNORECASE):
+                _LOGGER.warning(
+                    "Device returned error/empty response for command: %s; "
+                    "resetting connection",
+                    command.hex(),
+                )
+                # Proactively drop the connection without blocking
+                _LOGGER.log(TRACE, "_send_command(): before close_nowait() on error")
+                self.close_nowait()
+                _LOGGER.log(TRACE, "_send_command(): after close_nowait() on error")
+                msg = "Triad command error or empty response"
+                raise OSError(msg)
+            return text
+
+    async def send_raw(self, command: bytes) -> str:
+        """
+        Send a raw command and return the decoded response string.
+
+        Intended for diagnostic/debug usage. Uses the same transport, lock,
+        and parsing behavior as all other commands.
+        """
+        return await self._send_command(command)
 
     async def set_output_volume(self, output_channel: int, percentage: float) -> None:
         """
@@ -86,77 +149,27 @@ class TriadConnection:
             output_channel: 1-based output channel index.
             percentage: Volume as a float (0.0 = off, 1.0 = max).
         Command: FF 55 04 03 1E <output> <value>  (output sent as 0-based)
-        Value: 0x00 (off) to 0xA1 (max)
+        Value: 0x00 (off) to 0x64 (max)
 
         """
         _LOGGER.debug(
             "Request to set volume for output %d to %.2f", output_channel, percentage
         )
 
-        # Clamp to device range 0..1.0 (0x00..0xA1)
+        # Clamp to device range 0..1.0 (0x00..0x64)
         capped = max(0.0, min(percentage, 1.0))
 
-        val = int(capped * 0xA1)
-        val = max(0, min(val, 0xA1))
+        # Quantize to nearest device step for consistency (0..VOLUME_STEPS)
+        val = round(capped * VOLUME_STEPS)
+        val = max(0, min(val, VOLUME_STEPS))
         cmd = bytearray.fromhex("FF5504031E") + bytes([output_channel - 1, val])
-        resp = await self._send_command(cmd)
+        resp = await self._send_command(cmd, expect=r"Output\s+Volume|Volume\s*:")
         _LOGGER.info(
             "Set volume for output %d to %.2f (resp: %s)",
             output_channel,
             capped,
             resp,
         )
-
-    # --- Rolling poll/keepalive management ---
-    _poll_task: asyncio.Task | None = None
-    _pollers: list[callable] | None = None  # [async callables: () -> Awaitable[None]]
-    _poll_index: int = 0
-
-    def start_polling(self, pollers: list[callable], *, interval: float = 6.0) -> None:
-        """
-        Start or update a rolling poll over provided async pollers.
-
-        Each interval, the next poller is awaited, providing a steady
-        keep-alive and gradual state refresh across outputs.
-        """
-        self._pollers = list(pollers)
-        if self._poll_task is not None and not self._poll_task.done():
-            # Already running; just update the poller set
-            return
-
-        async def _loop() -> None:
-            _LOGGER.debug("Starting Triad rolling poll loop (interval=%.1fs)", interval)
-            try:
-                while True:
-                    try:
-                        # If we have no pollers, sleep to provide soft keepalive cadence
-                        if not self._pollers:
-                            await asyncio.sleep(interval)
-                        else:
-                            # Round-robin selection
-                            pollers_local = self._pollers
-                            idx = self._poll_index % len(pollers_local)
-                            self._poll_index += 1
-                            poller = pollers_local[idx]
-                            await poller()  # one output refresh
-                            await asyncio.sleep(interval)
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        _LOGGER.exception("Error during rolling poll; continuing")
-                        await asyncio.sleep(interval)
-            finally:
-                _LOGGER.debug("Triad rolling poll loop stopped")
-
-        self._poll_task = asyncio.create_task(_loop(), name="triad_ams_poll")
-
-    def stop_polling(self) -> None:
-        """Stop the rolling poll task, if running."""
-        if self._poll_task is not None:
-            self._poll_task.cancel()
-            self._poll_task = None
-        self._pollers = None
-        self._poll_index = 0
 
     async def get_output_volume(self, output_channel: int) -> float:
         """
@@ -170,18 +183,18 @@ class TriadConnection:
 
         """
         cmd = bytearray.fromhex("FF5504031EF5") + bytes([output_channel - 1])
-        resp = await self._send_command(cmd)
-        m = re.search(r"Volume : (-?\d+\.\d+|-?\d+)", resp)
-        if m:
-            # Device returns dB; convert to 0..1 scale
-            # Assume -80 dB is min and 0 dB is max
-            db = float(m.group(1))
-            # Clamp and scale: -80 dB -> 0.0, 0 dB -> 1.0
-            return max(0.0, min(1.0, (db + 80) / 80))
-        m_hex = re.search(r"Volume : 0x([0-9A-Fa-f]+)", resp)
+        resp = await self._send_command(cmd, expect=r"Volume\s*:")
+        # Prefer raw hex value if present (exact mapping to slider scale)
+        m_hex = re.search(r"Volume\s*:\s*0x([0-9A-Fa-f]+)", resp)
         if m_hex:
             value = int(m_hex.group(1), 16)
-            return value / 0xA1
+            return max(0.0, min(1.0, value / VOLUME_STEPS))
+        # Otherwise parse dB and map to nearest step using measured LUT
+        m = re.search(r"Volume\s*:\s*(-?\d+(?:\.\d+)?)", resp)
+        if m:
+            db = float(m.group(1))
+            step = step_for_db(db)
+            return step / VOLUME_STEPS
         _LOGGER.error("Could not parse output volume from response: %s", resp)
         return 0.0
 
@@ -218,7 +231,7 @@ class TriadConnection:
 
         """
         cmd = bytearray.fromhex("FF55040317F5") + bytes([output_channel - 1])
-        resp = await self._send_command(cmd)
+        resp = await self._send_command(cmd, expect=r"Mute")
         # Try to capture the token after "Mute" or "Mute status"
         m = re.search(r"Mute(?:\s+status)?\s*:\s*([A-Za-z0-9]+)", resp, re.IGNORECASE)
         if m:
@@ -242,7 +255,7 @@ class TriadConnection:
         cmd = bytearray.fromhex("FF55030315" if large else "FF55030313") + bytes(
             [output_channel - 1]
         )
-        resp = await self._send_command(cmd)
+        resp = await self._send_command(cmd, expect=r"(Input\s+Source|Audio\s+Off)")
         _LOGGER.debug(
             "Volume step up (%s) for output %d (resp: %s)",
             "large" if large else "small",
@@ -257,7 +270,7 @@ class TriadConnection:
         cmd = bytearray.fromhex("FF55030316" if large else "FF55030314") + bytes(
             [output_channel - 1]
         )
-        resp = await self._send_command(cmd)
+        resp = await self._send_command(cmd, expect=r"(Input\s+Source|Audio\s+Off)")
         _LOGGER.debug(
             "Volume step down (%s) for output %d (resp: %s)",
             "large" if large else "small",
@@ -280,7 +293,7 @@ class TriadConnection:
         cmd = bytearray.fromhex("FF5504031D") + bytes(
             [output_channel - 1, input_channel - 1]
         )
-        resp = await self._send_command(cmd)
+        resp = await self._send_command(cmd, expect=r"Trigger|Set\s+.*")
         # Be tolerant of varying response strings
         _LOGGER.info(
             "Set output %d to input %d (resp: %s)",
@@ -301,7 +314,10 @@ class TriadConnection:
 
         """
         cmd = bytearray.fromhex("FF5504031DF5") + bytes([output_channel - 1])
-        resp = await self._send_command(cmd)
+        # Accept "Audio Off", "Input Source : input N" or device 'Set ...' echoes
+        resp = await self._send_command(
+            cmd, expect=r"(Audio\s+Off|Input\s+Source|Set\s+.*)"
+        )
         if "Audio Off" in resp:
             return None
         m = re.search(r"input (\d+)", resp)
@@ -320,7 +336,7 @@ class TriadConnection:
 
         """
         cmd = bytearray.fromhex("FF5503055000" if on else "FF5503055100")
-        resp = await self._send_command(cmd)
+        resp = await self._send_command(cmd, expect=r"Max\s+Volume|0x|dB|Set\s+.*")
         _LOGGER.info("Set trigger zone to %s (resp: %s)", on, resp)
 
     async def disconnect_output(self, output_channel: int) -> None:
@@ -333,7 +349,7 @@ class TriadConnection:
 
         """
         cmd = bytearray.fromhex("FF5504031D") + bytes([output_channel - 1, INPUT_COUNT])
-        resp = await self._send_command(cmd)
+        resp = await self._send_command(cmd, expect=r"Start\s+Vol|0x|dB|Set\s+.*")
         # Tolerate varied responses and log outcome
         if "Audio Off" in resp:
             _LOGGER.info("Disconnected output %d (resp: %s)", output_channel, resp)

--- a/custom_components/triad_ams/const.py
+++ b/custom_components/triad_ams/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "triad_ams"
 INPUT_COUNT = 8
 OUTPUT_COUNT = 8
+VOLUME_STEPS = 0x64  # Device expects 0..0x64 (0..100) for volume-related values

--- a/custom_components/triad_ams/coordinator.py
+++ b/custom_components/triad_ams/coordinator.py
@@ -1,0 +1,216 @@
+"""
+Coordinator for Triad AMS.
+
+Fresh, minimal implementation that:
+- Sequences commands through a single worker
+- Enforces a minimum delay between commands
+- Avoids race conditions via a single queue
+- Drops transport on device-side errors (raised by connection)
+- Propagates errors to callers without internal retries
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import weakref
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from .models import TriadAmsOutput
+
+from .connection import TriadConnection
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class _Command:
+    """A queued coordinator command."""
+
+    op: Callable[[TriadConnection], Awaitable[Any]]
+    future: asyncio.Future
+
+
+class TriadCoordinator:
+    """Single-queue, single-worker command coordinator."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        min_send_interval: float = 0.15,
+        poll_interval: float = 30.0,
+    ) -> None:
+        """Initialize a paced, single-worker queue."""
+        self._host = host
+        self._port = port
+        self._conn = TriadConnection(host, port)
+        self._queue: asyncio.Queue[_Command] = asyncio.Queue()
+        self._worker: asyncio.Task | None = None
+        self._poll_task: asyncio.Task | None = None
+        self._last_send_time: float = 0.0
+        self._min_send_interval = max(0.0, min_send_interval)
+        self._poll_interval = max(1.0, poll_interval)
+        # Weak set of outputs to poll; avoids retaining entities
+        self._outputs: weakref.WeakSet[TriadAmsOutput] = weakref.WeakSet()
+        self._poll_index: int = 0
+
+    async def start(self) -> None:
+        """Start the single worker."""
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(self._run_worker(), name="triad_worker")
+        if self._poll_task is None or self._poll_task.done():
+            self._poll_task = asyncio.create_task(self._run_poll(), name="triad_poll")
+
+    async def stop(self) -> None:
+        """Stop the worker and cancel pending commands."""
+        if self._worker is not None:
+            self._worker.cancel()
+            # Drain queue and cancel futures
+            while not self._queue.empty():
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    cmd = self._queue.get_nowait()
+                    if not cmd.future.done():
+                        cmd.future.set_exception(asyncio.CancelledError())
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._worker
+            self._worker = None
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._poll_task
+            self._poll_task = None
+
+    async def disconnect(self) -> None:
+        """Disconnect from the device."""
+        await self._conn.disconnect()
+
+    # Registration for rolling poll
+    def register_output(self, output: TriadAmsOutput) -> None:
+        """Register an output for lightweight rolling polling."""
+        self._outputs.add(output)
+
+    async def _ensure_connection(self) -> None:
+        await asyncio.wait_for(self._conn.connect(), timeout=5)
+
+    async def _run_worker(self) -> None:
+        """Worker: dequeue, pace, ensure connection, execute, propagate result/error."""
+        while True:
+            cmd = await self._queue.get()
+            try:
+                # Enforce pacing
+                now = asyncio.get_running_loop().time()
+                delay = self._last_send_time + self._min_send_interval - now
+                if delay > 0:
+                    await asyncio.sleep(delay)
+
+                # Execute
+                await self._ensure_connection()
+                result = await cmd.op(self._conn)
+                self._last_send_time = asyncio.get_running_loop().time()
+                if not cmd.future.done():
+                    cmd.future.set_result(result)
+            except (
+                OSError,
+                TimeoutError,
+                asyncio.IncompleteReadError,
+                asyncio.CancelledError,
+            ) as exc:
+                # Log, drop transport, attempt quick reconnect, and propagate error.
+                _LOGGER.warning(
+                    "Command failed; dropping and reopening connection: %s", exc
+                )
+                self._conn.close_nowait()
+                # Best-effort immediate reconnect so subsequent commands are ready.
+                try:
+                    await asyncio.wait_for(self._conn.connect(), timeout=5)
+                    _LOGGER.info("Reconnected to Triad AMS after error")
+                except Exception as reconnect_exc:  # noqa: BLE001 - log and proceed
+                    _LOGGER.warning(
+                        "Reconnect attempt failed (will retry on next command): %s",
+                        reconnect_exc,
+                    )
+                if not cmd.future.done():
+                    cmd.future.set_exception(exc)
+            finally:
+                self._queue.task_done()
+
+    async def _run_poll(self) -> None:
+        """Round-robin poll: refresh one output every poll interval."""
+        while True:
+            outputs = [o for o in list(self._outputs) if o is not None]
+            if not outputs:
+                await asyncio.sleep(self._poll_interval)
+                continue
+            # Choose next output in a stable order
+            self._poll_index = self._poll_index % len(outputs)
+            target = outputs[self._poll_index]
+            self._poll_index += 1
+            try:
+                await target.refresh_and_notify()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Rolling poll refresh failed for output")
+            await asyncio.sleep(self._poll_interval)
+
+    async def _execute(self, op: Callable[[TriadConnection], Awaitable[Any]]) -> Any:
+        """Enqueue a command and await its result or error."""
+        future = asyncio.get_running_loop().create_future()
+        await self._queue.put(_Command(op=op, future=future))
+        return await future
+
+    # Public API
+    async def set_output_volume(self, output_channel: int, percentage: float) -> None:
+        """Set volume."""
+        await self._execute(lambda c: c.set_output_volume(output_channel, percentage))
+
+    async def get_output_volume(self, output_channel: int) -> float:
+        """Get volume (0..1)."""
+        return await self._execute(lambda c: c.get_output_volume(output_channel))
+
+    async def get_output_volume_from_device(self, output_channel: int) -> float:
+        """Explicit device read (testing)."""
+        return await self.get_output_volume(output_channel)
+
+    async def set_output_mute(self, output_channel: int, *, mute: bool) -> None:
+        """Set mute state."""
+        await self._execute(lambda c: c.set_output_mute(output_channel, mute=mute))
+
+    async def get_output_mute(self, output_channel: int) -> bool:
+        """Get mute state."""
+        return await self._execute(lambda c: c.get_output_mute(output_channel))
+
+    async def volume_step_up(self, output_channel: int, *, large: bool = False) -> None:
+        """Step volume up."""
+        await self._execute(lambda c: c.volume_step_up(output_channel, large=large))
+
+    async def volume_step_down(
+        self, output_channel: int, *, large: bool = False
+    ) -> None:
+        """Step volume down."""
+        await self._execute(lambda c: c.volume_step_down(output_channel, large=large))
+
+    async def set_output_to_input(
+        self, output_channel: int, input_channel: int
+    ) -> None:
+        """Route output to input."""
+        await self._execute(
+            lambda c: c.set_output_to_input(output_channel, input_channel)
+        )
+
+    async def get_output_source(self, output_channel: int) -> int | None:
+        """Get routed input (1-based) or None."""
+        return await self._execute(lambda c: c.get_output_source(output_channel))
+
+    async def disconnect_output(self, output_channel: int) -> None:
+        """Disconnect output."""
+        await self._execute(lambda c: c.disconnect_output(output_channel))
+
+    async def set_trigger_zone(self, *, on: bool) -> None:
+        """Set trigger zone on/off."""
+        await self._execute(lambda c: c.set_trigger_zone(on=on))

--- a/custom_components/triad_ams/volume_lut.py
+++ b/custom_components/triad_ams/volume_lut.py
@@ -1,0 +1,170 @@
+"""
+Measured Triad AMS volume lookup table (device-reported dB per step).
+
+Source: scripts/sweep_volume.py capturing Get Out[X] Volume : <dB> for steps 1..100.
+This table was measured on one output and appears consistent across outputs.
+
+STEP_TO_DB[step] -> dB value (float). Index 0 is unused (None) for 1-based steps.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_left
+
+# Index 0 is a placeholder so that index == step
+STEP_TO_DB: list[float | None] = [
+    None,
+    -100.3,
+    -92.7,
+    -85.8,
+    -79.5,
+    -73.9,
+    -69.0,
+    -64.6,
+    -61.0,
+    -58.0,
+    -55.6,
+    -53.9,
+    -52.0,
+    -50.5,
+    -49.6,
+    -48.7,
+    -47.7,
+    -46.8,
+    -45.9,
+    -45.0,
+    -44.1,
+    -43.2,
+    -42.3,
+    -41.4,
+    -40.6,
+    -39.7,
+    -38.9,
+    -38.0,
+    -37.2,
+    -36.4,
+    -35.6,
+    -34.8,
+    -34.0,
+    -33.2,
+    -32.4,
+    -31.7,
+    -30.9,
+    -30.2,
+    -29.4,
+    -28.7,
+    -28.0,
+    -27.2,
+    -26.5,
+    -25.8,
+    -25.1,
+    -24.5,
+    -23.8,
+    -23.1,
+    -22.5,
+    -21.8,
+    -21.2,
+    -20.5,
+    -19.9,
+    -19.3,
+    -18.7,
+    -18.1,
+    -17.5,
+    -16.9,
+    -16.4,
+    -15.8,
+    -15.3,
+    -14.7,
+    -14.2,
+    -13.7,
+    -13.1,
+    -12.6,
+    -12.1,
+    -11.6,
+    -11.1,
+    -10.7,
+    -10.2,
+    -9.7,
+    -9.3,
+    -8.9,
+    -8.4,
+    -8.0,
+    -7.6,
+    -7.2,
+    -6.8,
+    -6.4,
+    -6.0,
+    -5.6,
+    -5.3,
+    -4.9,
+    -4.6,
+    -4.2,
+    -3.9,
+    -3.6,
+    -3.3,
+    -3.0,
+    -2.7,
+    -2.4,
+    -2.1,
+    -1.8,
+    -1.6,
+    -1.3,
+    -1.1,
+    -0.9,
+    -0.6,
+    -0.4,
+    0.0,
+]
+
+# Build a monotonic list of (dB, step) for reverse lookup
+_DBS: list[float] = [db for db in STEP_TO_DB[1:] if db is not None]  # type: ignore[arg-type]
+
+
+def db_for_step(step: int) -> float:
+    """
+    Return measured dB for a device step (1..100).
+
+    Raises ValueError if out of range.
+    """
+    if step < 1 or step >= len(STEP_TO_DB):
+        msg = "step must be in 1..100"
+        raise ValueError(msg)
+    val = STEP_TO_DB[step]
+    assert val is not None  # noqa: S101
+    return float(val)
+
+
+def step_for_db(db: float) -> int:
+    """
+    Return the nearest device step (1..100) for a desired dB value.
+
+    Uses nearest neighbor on the measured monotonic curve.
+    """
+    # Find insertion point
+    i = bisect_left(_DBS, db)
+    if i <= 0:
+        return 1
+    if i >= len(_DBS):
+        return 100
+    # Choose closer neighbor
+    before = _DBS[i - 1]
+    after = _DBS[i]
+    dist_before = abs(db - before)
+    dist_after = abs(after - db)
+    return i if dist_after < dist_before else i - 1
+
+
+def percentage_for_step(step: int) -> float:
+    """Map device step to 0..1 percentage (exact quantization)."""
+    step = max(step, 1)
+    step = min(step, 100)
+    return step / 100.0
+
+
+def step_for_percentage(pct: float) -> int:
+    """Map 0..1 percentage to nearest device step (1..100)."""
+    pct = max(0.0, min(1.0, float(pct)))
+    step = round(pct * 100)
+    step = max(step, 1)
+    step = min(step, 100)
+    return int(step)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ homeassistant==2025.9.1
 home-assistant-frontend==20250903.3
 pip>=21.3.1
 ruff==0.13.0
+pre_commit==3.5.0

--- a/scripts/gen_brand_assets.py
+++ b/scripts/gen_brand_assets.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Generate PNG brand assets matching the SVG geometry.
 

--- a/scripts/send_command.py
+++ b/scripts/send_command.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Send a raw hex command to a Triad AMS switch and print the response.
+
+Usage:
+  ./scripts/send_command.py <ip> <port> <hex>
+
+Examples:
+  ./scripts/send_command.py 192.168.0.22 52000 "FF 55 04 03 1E 03 13"
+
+Notes:
+  - This script is independent of the Home Assistant integration code.
+  - It writes the provided bytes and reads one null-terminated frame back.
+
+"""
+# ruff: noqa: T201
+
+from __future__ import annotations
+
+import argparse
+import binascii
+import socket
+import sys
+import time
+
+
+def _clean_hex(s: str) -> bytes:
+    cleaned = "".join(ch for ch in s if ch in "0123456789abcdefABCDEF")
+    if not cleaned or len(cleaned) % 2 != 0:
+        msg = "hex must contain an even number of hex digits"
+        raise ValueError(msg)
+    try:
+        return bytes.fromhex(cleaned)
+    except binascii.Error as err:  # pragma: no cover - safety
+        msg = "invalid hex input"
+        raise ValueError(msg) from err
+
+
+def _read_until_null(sock: socket.socket, *, timeout: float = 5.0) -> bytes:
+    sock.settimeout(timeout)
+    buf = bytearray()
+    while True:
+        b = sock.recv(1)
+        if not b:
+            msg = "connection closed before null terminator"
+            raise TimeoutError(msg)
+        if b == b"\x00":
+            break
+        buf.extend(b)
+    return bytes(buf)
+
+
+def main(argv: list[str]) -> int:
+    """Send a raw hex command to a Triad AMS switch and print the response."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ip", help="Triad AMS IP address")
+    parser.add_argument("port", type=int, help="Triad AMS TCP port (e.g., 52000)")
+    parser.add_argument(
+        "hex", help="Hex string, spaces allowed (e.g., 'FF 55 03 05 50 00')"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=5.0, help="Read timeout seconds (default: 5)"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        payload = _clean_hex(args.hex)
+    except ValueError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 2
+
+    addr = (args.ip, args.port)
+    print(f"Connecting to {addr[0]}:{addr[1]} ...")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(5.0)
+        s.connect(addr)
+        # Some devices need a small settle time after connect
+        time.sleep(0.2)
+
+        print(f"Sending ({len(payload)} bytes): {payload.hex()}")
+        s.sendall(payload)
+        # Read one null-terminated frame
+        try:
+            frame = _read_until_null(s, timeout=args.timeout)
+        except TimeoutError as err:
+            print(f"Timed out waiting for response: {err}", file=sys.stderr)
+            return 1
+
+        text = frame.decode(errors="replace").strip()
+        print(f"Received ({len(frame)} bytes): {frame.hex()}")
+        print(f"Decoded: {text}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/sweep_volume.py
+++ b/scripts/sweep_volume.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# sweep_volume.py
+# Usage: ./sweep_volume.py <ip> <port> <output_channel 1..8>
+#    [--start 1]
+#    [--end 100]
+#    [--sleep 0.15]
+# ruff: noqa: T201
+"""Sweep volume levels for a given output channel."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import socket
+import sys
+import time
+
+
+def read_until_null(sock: socket.socket, timeout: float = 5.0) -> bytes:
+    """Read until a null terminator is received."""
+    sock.settimeout(timeout)
+    buf = bytearray()
+    while True:
+        b = sock.recv(1)
+        if not b:
+            msg = "connection closed before null terminator"
+            raise TimeoutError(msg)
+        if b == b"\x00":
+            break
+        buf.extend(b)
+    return bytes(buf)
+
+
+def send_and_read(sock: socket.socket, payload: bytes, timeout: float = 5.0) -> str:
+    """Send a payload and read the response."""
+    sock.sendall(payload)
+    frame = read_until_null(sock, timeout=timeout)
+    text = frame.decode(errors="replace").strip("\x00").strip()
+    # Skip one unsolicited AudioSense event if it appears
+    if re.search(r"^AudioSense:Input\[\d+\]\s*:\s*(0|1)\s*$", text, re.IGNORECASE):
+        # Read next frame
+        frame = read_until_null(sock, timeout=timeout)
+        text = frame.decode(errors="replace").strip("\x00").strip()
+    return text
+
+
+def main(argv: list[str]) -> int:
+    """Sweep volume levels for a given output channel."""
+    p = argparse.ArgumentParser()
+    p.add_argument("ip")
+    p.add_argument("port", type=int)
+    p.add_argument("output", type=int)
+    p.add_argument("--start", type=int, default=1)
+    p.add_argument("--end", type=int, default=100)
+    p.add_argument("--sleep", type=float, default=0.15, help="delay between commands")
+    p.add_argument("--timeout", type=float, default=5.0)
+    args = p.parse_args(argv)
+    out_idx = args.output - 1
+    if out_idx < 0 or out_idx > 7:  # noqa: PLR2004
+        print("output must be 1..8", file=sys.stderr)
+        return 2
+
+    addr = (args.ip, args.port)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(5.0)
+        s.connect(addr)
+        time.sleep(0.2)
+
+        print("step,db,raw")
+        for step in range(args.start, args.end + 1):
+            # Set volume: FF 55 04 03 1E <out> <step>
+            set_cmd = bytes.fromhex("FF5504031E") + bytes([out_idx, step])
+            _ = send_and_read(s, set_cmd, timeout=args.timeout)
+            time.sleep(args.sleep)
+            # Query dB: FF 55 04 03 1E F5 <out>
+            get_cmd = bytes.fromhex("FF5504031EF5") + bytes([out_idx])
+            txt2 = send_and_read(s, get_cmd, timeout=args.timeout)
+            m = re.search(r"Volume\s*:\s*(-?\d+(?:\.\d+)?)", txt2)
+            db = m.group(1) if m else ""
+            print(f"{step},{db},{txt2}")
+            time.sleep(args.sleep)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
- Replace coordinator with single-queue, paced worker; drop retries; propagate errors
- Connection: single-frame responses, skip one AudioSense unsolicited frame; 5s timeouts
- Add measured volume LUT and map dB↔step to prevent drift; keep hex path
- Media player/entities: simpler setup; initial one-shot refresh; register for rolling poll
- Add minimal 30s rolling poll to maintain eventual consistency and keep connection alive
- Remove debug/test services and unused helpers; tidy imports and lints
- Add scripts for raw command send and volume sweep; brand assets shebang
