### PR TITLE
fix: add command timestamp to prevent post-command poll race condition

### DIFF
--- a/custom_components/triad_ams/models.py
+++ b/custom_components/triad_ams/models.py
@@ -8,6 +8,7 @@ from .const import VOLUME_STEPS
 from .coordinator import TriadCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+_POST_COMMAND_REFRESH_COOLDOWN_S = 3.0
 
 
 class TriadAmsOutput:
@@ -184,13 +185,14 @@ class TriadAmsOutput:
 
     async def refresh(self) -> None:
         """Refresh the state from the device (on demand only)."""
+        elapsed = time.monotonic() - self._last_command_time
+        if elapsed < _POST_COMMAND_REFRESH_COOLDOWN_S:
+            _LOGGER.debug(
+                "Output %d: command sent recently, skipping refresh",
+                self.number,
+            )
+            return
         try:
-            if time.monotonic() - self._last_command_time < 3.0:
-                _LOGGER.debug(
-                    "Output %d: command sent recently, skipping refresh",
-                    self.number,
-                )
-                return
             self._volume = await self.coordinator.get_output_volume(self.number)
         except OSError:
             _LOGGER.exception("Failed to refresh volume for output %d", self.number)

--- a/custom_components/triad_ams/models.py
+++ b/custom_components/triad_ams/models.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import logging
+import time
 
 from .const import VOLUME_STEPS
 from .coordinator import TriadCoordinator
@@ -38,6 +39,7 @@ class TriadAmsOutput:
         self._outputs = outputs
         # Lightweight listener callbacks invoked after refreshes
         self._listeners: list[callable] = []
+        self._last_command_time: float = 0.0
 
     # ---- Listener management for state updates ----
     def add_listener(self, cb: callable) -> callable:
@@ -97,6 +99,7 @@ class TriadAmsOutput:
             self._last_assigned_input = input_id
             # Turning on (UI) implicitly when a source is routed
             self._ui_on = True
+            self._last_command_time = time.monotonic()
         except OSError:
             _LOGGER.exception("Failed to set source for output %d", self.number)
 
@@ -117,6 +120,7 @@ class TriadAmsOutput:
             quantized = steps / VOLUME_STEPS
             await self.coordinator.set_output_volume(self.number, quantized)
             self._volume = quantized
+            self._last_command_time = time.monotonic()
         except OSError:
             _LOGGER.exception("Failed to set volume for output %d", self.number)
 
@@ -130,6 +134,7 @@ class TriadAmsOutput:
         try:
             await self.coordinator.set_output_mute(self.number, mute=muted)
             self._muted = muted
+            self._last_command_time = time.monotonic()
         except OSError:
             _LOGGER.exception("Failed to set mute for output %d", self.number)
 
@@ -161,6 +166,7 @@ class TriadAmsOutput:
             await self.coordinator.disconnect_output(self.number)
             self._assigned_input = None
             self._ui_on = False
+            self._last_command_time = time.monotonic()
         except OSError:
             _LOGGER.exception("Failed to turn off output %d", self.number)
 
@@ -174,10 +180,17 @@ class TriadAmsOutput:
             await self.set_source(self._last_assigned_input)
         else:
             self._ui_on = True
+            self._last_command_time = time.monotonic()
 
     async def refresh(self) -> None:
         """Refresh the state from the device (on demand only)."""
         try:
+            if time.monotonic() - self._last_command_time < 3.0:
+                _LOGGER.debug(
+                    "Output %d: command sent recently, skipping refresh",
+                    self.number,
+                )
+                return
             self._volume = await self.coordinator.get_output_volume(self.number)
         except OSError:
             _LOGGER.exception("Failed to refresh volume for output %d", self.number)

--- a/tests/integration/test_entity_lifecycle.py
+++ b/tests/integration/test_entity_lifecycle.py
@@ -75,7 +75,7 @@ class TestEntityLifecycle:
     async def test_output_refresh_updates_state(
         self, output_fixture: TriadAmsOutput
     ) -> None:
-        """Test that refresh updates volume and source from device, but not mute."""
+        """Test that refresh updates volume, mute, and source from device."""
         output = output_fixture
 
         # Set state via commands
@@ -85,10 +85,10 @@ class TestEntityLifecycle:
 
         # Clear local state
         output._volume = None
-        # refresh() no longer queries mute; mute state is tracked optimistically
         output._assigned_input = None
+        output._last_command_time = 0.0  # bypass post-command cooldown
 
-        # Refresh should restore volume and source only
+        # Refresh should restore volume and source
         await output.refresh()
         assert abs(output.volume - 0.6) < 0.1
         assert output.source == 2


### PR DESCRIPTION
## Problem

State-mutating commands (`set_source`, `turn_on`, `turn_off`, `set_volume`, `set_muted`) set optimistic in-memory state immediately after sending the command over TCP. This works fine in isolation.

However, the `refresh()` poll runs every 30 seconds in round-robin across outputs. If the poll hits an output shortly after a state-changing command, it reads whatever state the matrix currently has — which may not yet reflect the just-sent command if the matrix hasn't fully applied it.

Concrete failure sequence:

1. User issues `turn_on` on output N
2. `turn_on` → `set_source(last_input)` → `_ui_on = True`, `_assigned_input = X`
3. Command sent to matrix; audio starts
4. ~0.5 seconds later, the poll happens to land on output N
5. `get_output_source(N)` queries the matrix
6. Matrix returns `None` (routing not yet applied) or an out-of-range value
7. `refresh()` falls into the `else` branch: `_ui_on = False`, `_assigned_input = None`
8. HA now shows the zone as off, but audio is playing

Same race, opposite direction, for `turn_off`: the poll sees the source still assigned (momentarily) and overwrites `_ui_on = False` back to `True`.

This is less severe than the mute query issue (PR #89) but is a real user-visible bug: turn_on/turn_off commands appear to randomly "fail" (not revert on the matrix side — the audio is correct — but HA's state is wrong).

## Fix

Add a `_last_command_time` timestamp to the `Output` model, using `time.monotonic()`. Every state-changing command updates this timestamp after a successful TCP write. At the top of `refresh()`, check whether a command was issued within the last 3 seconds; if so, skip the refresh for that output.

3 seconds is a conservative window — in practice the matrix applies commands in under a second — but it cleanly eliminates the race with no observable downside (one missed poll cycle, next one catches up).

## Changes

`models.py` only:

1. Add `import time`
2. Add `self._last_command_time: float = 0.0` to `__init__`
3. Add `self._last_command_time = time.monotonic()` at the end of each command method: `set_source`, `set_volume`, `set_muted`, `turn_off`, and the else-branch of `turn_on` (the other branch delegates to `set_source` which already sets the timestamp)
4. Guard at the top of `refresh()`:
```python
   if time.monotonic() - self._last_command_time < 3.0:
       _LOGGER.debug("Output %d: command sent recently, skipping refresh", self.number)
       return
```

## Testing

- Confirmed turn_on followed by natural poll cycle: state remains "on" correctly, no longer reverts
- Confirmed turn_off: state remains "off" correctly
- Confirmed rapid command sequences (turn_on → set_source → turn_off within a few seconds) all land correctly
- Confirmed out-of-band state changes are still detected (after the 3-second cooldown expires)

## Notes

This doesn't address the architectural limitation that the integration is polling-only with no push listener (Control4 changes take up to 30 seconds to be detected by HA). That's a separate, larger piece of work (SDDP listener).