### PR TITLE
feat: forward media position and enable progress bar rendering

### DIFF
--- a/custom_components/triad_ams/media_player.py
+++ b/custom_components/triad_ams/media_player.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-from homeassistant.util import dt as dt_util
 
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
@@ -20,6 +19,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -438,7 +438,7 @@ class TriadAmsMediaPlayer(MediaPlayerEntity):
     def media_album_name(self) -> str | None:
         """Return the media album from the linked source, if any."""
         return self._linked_attr("media_album_name")
-    
+
     @property
     def media_position(self) -> float | None:
         """Return the current playback position from the linked source, if any."""
@@ -499,7 +499,7 @@ class TriadAmsMediaPlayer(MediaPlayerEntity):
 
     @property
     def state(self) -> str:
-        """Return the state: UNAVAILABLE, OFF, or ON/PLAYING/PAUSED mirrored from source."""
+        """Return UNAVAILABLE, OFF, or ON/PLAYING/PAUSED mirrored from source."""
         if not self.available:
             # Return None for unavailable state (Home Assistant convention)
             return None

--- a/custom_components/triad_ams/media_player.py
+++ b/custom_components/triad_ams/media_player.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from homeassistant.util import dt as dt_util
 
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
@@ -317,6 +318,7 @@ class TriadAmsMediaPlayer(MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.SEEK
     )
     _attr_should_poll = False
     _attr_has_entity_name = True
@@ -436,6 +438,21 @@ class TriadAmsMediaPlayer(MediaPlayerEntity):
     def media_album_name(self) -> str | None:
         """Return the media album from the linked source, if any."""
         return self._linked_attr("media_album_name")
+    
+    @property
+    def media_position(self) -> float | None:
+        """Return the current playback position from the linked source, if any."""
+        return self._linked_attr("media_position")
+
+    @property
+    def media_position_updated_at(self) -> object | None:
+        """Return when media_position was last updated as a timezone-aware datetime."""
+        val = self._linked_attr("media_position_updated_at")
+        if val is None:
+            return None
+        if isinstance(val, str):
+            return dt_util.parse_datetime(val)
+        return val
 
     @property
     def media_duration(self) -> int | None:
@@ -482,11 +499,20 @@ class TriadAmsMediaPlayer(MediaPlayerEntity):
 
     @property
     def state(self) -> str:
-        """Return the state of the entity (STATE_ON, STATE_OFF, or UNAVAILABLE)."""
+        """Return the state: UNAVAILABLE, OFF, or ON/PLAYING/PAUSED mirrored from source."""
         if not self.available:
             # Return None for unavailable state (Home Assistant convention)
             return None
-        return MediaPlayerState.ON if self.is_on else MediaPlayerState.OFF
+        if not self.is_on:
+            return MediaPlayerState.OFF
+        if self._linked_entity_id and self.hass is not None:
+            linked_state = self.hass.states.get(self._linked_entity_id)
+            if linked_state is not None:
+                if linked_state.state == MediaPlayerState.PLAYING:
+                    return MediaPlayerState.PLAYING
+                if linked_state.state == MediaPlayerState.PAUSED:
+                    return MediaPlayerState.PAUSED
+        return MediaPlayerState.ON
 
     @property
     def source(self) -> str | None:
@@ -586,6 +612,23 @@ class TriadAmsMediaPlayer(MediaPlayerEntity):
         await self.output.volume_down_step(large=False)
         await self.output.refresh()
         self.async_write_ha_state()
+
+    async def async_media_seek(self, position: float) -> None:
+        """Forward seek to the linked source entity."""
+        if not self._linked_entity_id or self.hass is None:
+            return
+        _LOGGER.debug(
+            "Forwarding seek on output %d to %s: position=%.2f",
+            self.output.number,
+            self._linked_entity_id,
+            position,
+        )
+        await self.hass.services.async_call(
+            "media_player",
+            "media_seek",
+            {"entity_id": self._linked_entity_id, "seek_position": position},
+            blocking=False,
+        )
 
     async def async_turn_off(self) -> None:
         """Turn off the output (disconnect from any input)."""


### PR DESCRIPTION
## Problem

Output `media_player` entities forward most media metadata from their linked source entity (title, artist, album art, duration) but not position information. This causes the HA frontend to show `0:00 / [duration]` with no progress bar for all playing zones, even when the upstream source reports position correctly.

## Investigation

Adding `media_position` and `media_position_updated_at` as properties on the entity was not sufficient on its own. The HA frontend has several requirements before it renders a progress bar:

1. All three of `media_duration`, `media_position`, and `media_position_updated_at` must be non-None (not just forwarded, but populated)
2. The `supported_features` bitmask must include the SEEK flag
3. The entity state must be `playing` or `paused` — not just `on`

The existing integration satisfied only (1) partially (duration forwarded, but not position or updated_at), and failed (2) and (3) entirely. Additionally, enabling SEEK without implementing `async_media_seek` would cause an error when users interact with the now-draggable slider.

## Fix

Four coordinated changes to `media_player.py`:

### 1. Forward media position attributes

Two new properties using the existing `_linked_attr` helper:

```python
@property
def media_position(self) -> float | None:
    return self._linked_attr("media_position")

@property
def media_position_updated_at(self) -> object | None:
    val = self._linked_attr("media_position_updated_at")
    if val is None:
        return None
    if isinstance(val, str):
        return dt_util.parse_datetime(val)
    return val
```

The datetime handling is defensive: `media_position_updated_at` from an in-memory entity state is typically already a `datetime` object, but after HA state restore from disk it may be an ISO 8601 string.

### 2. Add SEEK to supported_features

One line added to the existing `_attr_supported_features` bitmask.

### 3. Mirror source state when playing

The `state` property previously returned only `ON`/`OFF`/`UNAVAILABLE`. Updated to mirror the linked source's `playing`/`paused` state when available:

```python
@property
def state(self) -> str:
    """Return the state: UNAVAILABLE, OFF, or ON/PLAYING/PAUSED mirrored from source."""
    if not self.available:
        return None
    if not self.is_on:
        return MediaPlayerState.OFF
    if self._linked_entity_id and self.hass is not None:
        linked_state = self.hass.states.get(self._linked_entity_id)
        if linked_state is not None:
            if linked_state.state == MediaPlayerState.PLAYING:
                return MediaPlayerState.PLAYING
            if linked_state.state == MediaPlayerState.PAUSED:
                return MediaPlayerState.PAUSED
    return MediaPlayerState.ON
```

Preserves the existing UNAVAILABLE handling. Falls back to ON for zones with no linked entity (e.g., TOSLINK TV inputs) or sources reporting other states (idle, buffering, etc.).

### 4. Implement async_media_seek

Forwards seek operations to the linked source entity via the `media_player.media_seek` service. Silently no-ops if no linked entity.

## Behavior

- **Zones playing a streaming source** (AirPlay, Chromecast, Lynk, etc.): progress bar renders with live-updating elapsed/remaining times; seek slider works
- **Zones paused**: progress bar shows frozen position; state shows PAUSED
- **Zones routed to non-streaming sources** (TV TOSLINK, etc.): no progress bar, state shows ON (correct)
- **Zones with no source assigned**: state shows OFF (unchanged)
- **Unavailable entities**: state returns None (unchanged)

## Testing

- Confirmed progress bar renders and advances live on Triad outputs playing from a Lynk streamer
- Confirmed pause on source propagates to Triad output, progress bar freezes correctly
- Confirmed seek by dragging slider on Triad output card: audio jumps to new position on both Lynk and Triad, no errors
- Confirmed TV TOSLINK zones show no progress bar (correctly, source has no position concept)
- Confirmed song changes on source propagate to Triad output (title, artist, album art, duration, position all update)
- Confirmed no regression in existing state transitions (on/off, source change, volume)

## Note on state semantic change

This PR changes the semantic of the `state` property. Users with automations that trigger on `state: on` for Triad entities may need to update their automations to also handle `state: playing` and `state: paused`, since the entity will now report those states when the linked source is actively playing. This is consistent with how HA's own media player entities behave.