### PR TITLE
chore(devcontainer): mount host ~/.claude.json and ~/.gitconfig

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,6 +53,8 @@
   },
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind",
+    "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind",
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
   ]
 }


### PR DESCRIPTION
## Summary
- Bring this devcontainer in line with the other `homeassistant-*` repos (`control4-dimmers`, `lockly`, `bromic-smart-heat-link`) so a dispatched Claude inside the container shares OAuth tokens (`~/.claude.json`) and git author identity (`~/.gitconfig`) with the orchestrator host.
- The `~/.claude` memory mount was already present.

## Test plan
- [x] Devcontainer JSON is valid; existing `~/.claude` mount preserved.
- [ ] After merge, `devcontainer up --workspace-folder .` reuses the existing container until rebuilt; a fresh build picks up the new mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)