### PR TITLE
fix(connection): distinguish transient device errors from TCP failures (closes #102)

### DIFF
--- a/custom_components/triad_ams/connection.py
+++ b/custom_components/triad_ams/connection.py
@@ -20,6 +20,7 @@ from .const import (
     POST_CONNECT_DELAY,
     VOLUME_STEPS,
 )
+from .exceptions import TransientDeviceError
 from .volume_lut import step_for_db
 
 _LOGGER = logging.getLogger(__name__)
@@ -156,19 +157,19 @@ class TriadConnection:
         self, text: str, _expect: str | None, command: bytes
     ) -> None:
         """Validate response text against expected pattern."""
-        # Detect device-side command error or protocol desync (nulls)
+        # Detect device-side command error or protocol desync (nulls).
+        # The matrix firmware intermittently returns empty responses on
+        # otherwise-healthy TCP connections (most often for `get_output_mute`,
+        # also seen on volume / source queries). Treat these as transient
+        # *application-layer* failures — propagate to the caller without
+        # tearing down the socket. See issue #102.
         if text == "" or re.search(r"^command\s+error$", text, re.IGNORECASE):
-            _LOGGER.warning(
-                "Device returned error/empty response for command: %s; "
-                "resetting connection",
+            _LOGGER.debug(
+                "Device returned error/empty response for command: %s",
                 command.hex(),
             )
-            # Proactively drop the connection without blocking
-            self._log_protocol("_send_command(): before close_nowait() on error")
-            self.close_nowait()
-            self._log_protocol("_send_command(): after close_nowait() on error")
             msg = "Triad command error or empty response"
-            raise OSError(msg)
+            raise TransientDeviceError(msg)
 
     async def _send_command(self, command: bytes, *, expect: str | None = None) -> str:
         """

--- a/custom_components/triad_ams/coordinator.py
+++ b/custom_components/triad_ams/coordinator.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 from .connection import TriadConnection
 from .const import CONNECTION_TIMEOUT, NETWORK_EXCEPTIONS, SHUTDOWN_TIMEOUT
+from .exceptions import TransientDeviceError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -211,7 +212,7 @@ class TriadCoordinator:
             _LOGGER.info("Triad AMS device available")
             self._notify_availability_listeners(is_available=True)
 
-    async def _run_worker(self) -> None:
+    async def _run_worker(self) -> None:  # noqa: PLR0912
         """Worker: dequeue, pace, ensure connection, execute, propagate result/error."""
         while True:
             cmd = await self._queue.get()
@@ -233,6 +234,17 @@ class TriadCoordinator:
                 if not cmd.future.done():
                     cmd.future.cancel()
                 raise
+            except TransientDeviceError as exc:
+                # Application-layer device shrug (empty / malformed response)
+                # on a healthy TCP socket. Do NOT drop the connection or flip
+                # availability — propagate to the caller so it can decide
+                # whether to retry, skip, or surface. See issue #102.
+                _LOGGER.debug(
+                    "Transient device error; propagating without reconnect: %s",
+                    exc,
+                )
+                if not cmd.future.done():
+                    cmd.future.set_exception(exc)
             except NETWORK_EXCEPTIONS as exc:
                 # Log, drop transport, attempt quick reconnect, and propagate error.
                 _LOGGER.warning(

--- a/custom_components/triad_ams/exceptions.py
+++ b/custom_components/triad_ams/exceptions.py
@@ -1,0 +1,20 @@
+"""Exceptions for the Triad AMS integration."""
+
+from __future__ import annotations
+
+
+class TransientDeviceError(Exception):
+    """
+    Empty / malformed device response on a healthy TCP socket.
+
+    Distinct from `OSError` / `TimeoutError` / `asyncio.IncompleteReadError`
+    (transport-layer failures) — those still belong in
+    `const.NETWORK_EXCEPTIONS` and trigger the coordinator's reconnect path.
+
+    `TransientDeviceError` is the integration's signal that the matrix
+    firmware shrugged at an application-layer query (typical pattern: empty
+    response on ~10% of polls for certain commands). Callers should
+    propagate / log / skip the query *without* tearing down the socket.
+
+    Background: https://github.com/bharat/homeassistant-triad-ams/issues/102
+    """

--- a/custom_components/triad_ams/models.py
+++ b/custom_components/triad_ams/models.py
@@ -6,6 +6,7 @@ import time
 
 from .const import VOLUME_STEPS
 from .coordinator import TriadCoordinator
+from .exceptions import TransientDeviceError
 
 _LOGGER = logging.getLogger(__name__)
 _POST_COMMAND_REFRESH_COOLDOWN_S = 3.0
@@ -101,7 +102,7 @@ class TriadAmsOutput:
             # Turning on (UI) implicitly when a source is routed
             self._ui_on = True
             self._last_command_time = time.monotonic()
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to set source for output %d", self.number)
 
     @property
@@ -122,7 +123,7 @@ class TriadAmsOutput:
             await self.coordinator.set_output_volume(self.number, quantized)
             self._volume = quantized
             self._last_command_time = time.monotonic()
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to set volume for output %d", self.number)
 
     @property
@@ -136,21 +137,21 @@ class TriadAmsOutput:
             await self.coordinator.set_output_mute(self.number, mute=muted)
             self._muted = muted
             self._last_command_time = time.monotonic()
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to set mute for output %d", self.number)
 
     async def volume_up_step(self, *, large: bool = False) -> None:
         """Step the volume up (optionally large step)."""
         try:
             await self.coordinator.volume_step_up(self.number, large=large)
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to step volume up for output %d", self.number)
 
     async def volume_down_step(self, *, large: bool = False) -> None:
         """Step the volume down (optionally large step)."""
         try:
             await self.coordinator.volume_step_down(self.number, large=large)
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to step volume down for output %d", self.number)
 
     @property
@@ -168,7 +169,7 @@ class TriadAmsOutput:
             self._assigned_input = None
             self._ui_on = False
             self._last_command_time = time.monotonic()
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to turn off output %d", self.number)
 
     async def turn_on(self) -> None:
@@ -194,7 +195,7 @@ class TriadAmsOutput:
             return
         try:
             self._volume = await self.coordinator.get_output_volume(self.number)
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to refresh volume for output %d", self.number)
             return
 
@@ -204,12 +205,12 @@ class TriadAmsOutput:
         # reconnect path (since OSError propagating out of refresh would
         # cascade into _run_worker's connection-reset behavior).
         # Mute state is also tracked optimistically via set_muted().
-        with contextlib.suppress(OSError):
+        with contextlib.suppress(OSError, TransientDeviceError):
             self._muted = await self.coordinator.get_output_mute(self.number)
 
         try:
             assigned_input = await self.coordinator.get_output_source(self.number)
-        except OSError:
+        except (OSError, TransientDeviceError):
             _LOGGER.exception("Failed to refresh source for output %d", self.number)
             return
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.triad_ams.connection import TriadConnection
+from custom_components.triad_ams.exceptions import TransientDeviceError
 from tests.conftest import create_async_mock_method
 
 
@@ -215,15 +216,28 @@ class TestTriadConnectionSendCommand:
         mock_stream_reader: MagicMock,
         mock_stream_writer: MagicMock,
     ) -> None:
-        """Test handling of error response."""
+        """
+        An "error" / empty payload raises TransientDeviceError, NOT OSError.
+
+        The connection MUST remain open (this is the issue #102 fix: empty
+        responses come from a healthy TCP socket, so the coordinator should
+        not tear down + reconnect on them).
+        """
         mock_stream_reader.readuntil = create_async_mock_method(
             return_value=b"command error\x00"
         )
         connection._reader = mock_stream_reader
         connection._writer = mock_stream_writer
+        # Spy on close_nowait so we can assert it's NOT called on this path.
+        with patch.object(connection, "close_nowait") as close_spy:
+            with pytest.raises(TransientDeviceError, match="Triad command error"):
+                await connection._send_command(b"\xff\x55")
+            close_spy.assert_not_called()
 
-        with pytest.raises(OSError, match="Triad command error"):
-            await connection._send_command(b"\xff\x55")
+        # Sanity: TransientDeviceError is intentionally NOT an OSError, so
+        # callers that catch only OSError will let it propagate. That's the
+        # point — `_run_worker`'s NETWORK_EXCEPTIONS path must not swallow it.
+        assert not issubclass(TransientDeviceError, OSError)
 
     @pytest.mark.asyncio
     async def test_send_command_empty_response(
@@ -232,13 +246,15 @@ class TestTriadConnectionSendCommand:
         mock_stream_reader: MagicMock,
         mock_stream_writer: MagicMock,
     ) -> None:
-        """Test handling of empty response."""
+        """An empty payload also raises TransientDeviceError without closing."""
         mock_stream_reader.readuntil = create_async_mock_method(return_value=b"\x00")
         connection._reader = mock_stream_reader
         connection._writer = mock_stream_writer
 
-        with pytest.raises(OSError, match="Triad command error"):
-            await connection._send_command(b"\xff\x55")
+        with patch.object(connection, "close_nowait") as close_spy:
+            with pytest.raises(TransientDeviceError, match="Triad command error"):
+                await connection._send_command(b"\xff\x55")
+            close_spy.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_command_timeout(

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -11,6 +11,7 @@ from custom_components.triad_ams.coordinator import (
     TriadCoordinatorConfig,
     _Command,
 )
+from custom_components.triad_ams.exceptions import TransientDeviceError
 from custom_components.triad_ams.models import TriadAmsOutput
 from tests.conftest import create_async_mock_method
 
@@ -312,6 +313,40 @@ class TestTriadCoordinatorErrorHandling:
 
         with pytest.raises(TimeoutError):
             await coordinator.get_output_volume(1)
+
+        await coordinator.stop()
+
+    @pytest.mark.asyncio
+    async def test_transient_device_error_propagates_without_reconnect(
+        self, coordinator: TriadCoordinator, mock_connection: MagicMock
+    ) -> None:
+        """
+        TransientDeviceError must propagate but NOT touch the connection.
+
+        Issue #102: an empty/malformed application-layer response on a
+        healthy TCP socket should reach the caller without `_run_worker`
+        calling `close_nowait` or flipping `_available` to False.
+        """
+        mock_connection.get_output_volume.side_effect = TransientDeviceError(
+            "Triad command error or empty response"
+        )
+        mock_connection.close_nowait = MagicMock()
+        await coordinator.start()
+
+        listener = MagicMock()
+        coordinator.add_availability_listener(listener)
+
+        with pytest.raises(
+            TransientDeviceError, match="Triad command error or empty response"
+        ):
+            await coordinator.get_output_volume(1)
+
+        # Critical assertions for the issue #102 fix:
+        # 1. Socket NOT torn down.
+        mock_connection.close_nowait.assert_not_called()
+        # 2. Availability NOT flipped (no listener notification).
+        listener.assert_not_called()
+        assert coordinator.is_available is True
 
         await coordinator.stop()
 


### PR DESCRIPTION
## Summary
Implements the fix proposed in issue [#102](https://github.com/bharat/homeassistant-triad-ams/issues/102). The matrix firmware intermittently returns empty / "command error" responses on otherwise-healthy TCP sockets (most often for `get_output_mute`, also seen on volume / source queries). Previously this surfaced as `OSError`, which is in `NETWORK_EXCEPTIONS`, so `_run_worker` tore down the socket and reconnected every time. @bulent-1977 measured ~6 reconnects/min on a 3-zone, 30s-poll setup.

## What changed
- **`exceptions.py`** (new): `TransientDeviceError(Exception)` — deliberately **not** an `OSError` subclass, so it stays out of `NETWORK_EXCEPTIONS`.
- **`connection.py`**: `_validate_response`'s empty-response branch now raises `TransientDeviceError` and does **NOT** call `close_nowait()`. The socket stays up.
- **`coordinator.py`**: new `except TransientDeviceError` arm in `_run_worker`, placed **before** the `NETWORK_EXCEPTIONS` arm. Propagates the error to the caller's future without touching the connection or flipping availability.
- **`models.py`**: 8 `except OSError:` arms broadened to `except (OSError, TransientDeviceError):`. The existing `contextlib.suppress(OSError)` around the mute query also catches the new exception.

## Tests
- `test_connection.py`: existing empty/error-response tests now assert `TransientDeviceError` (not `OSError`) **AND** that `close_nowait` is NOT called. Sanity check that `TransientDeviceError` is not an `OSError` subclass.
- `test_coordinator.py`: new `test_transient_device_error_propagates_without_reconnect` asserts the worker propagates the error, leaves `close_nowait` uncalled, and does NOT flip `is_available` to False or notify availability listeners.

All **256 tests pass** locally (+1 new test; the 2 existing connection tests were rewritten to assert the new behavior, not added to).

## Net effect
- The reconnect storm in @bulent-1977's repro setup should drop from ~6/min to **0** for the empty-response case.
- Existing `OSError` / `TimeoutError` / `IncompleteReadError` paths are unchanged — genuine network failures still drop and reconnect.
- May also resolve user-reported [#69](https://github.com/bharat/homeassistant-triad-ams/issues/69) ("White / Digital Noise when C4 controller updates zones") if the theory that TCP churn was disturbing the matrix's audio routing is correct.

## Test plan
- [x] Existing test suite passes (255/255 → 256/256 with the new test).
- [x] Ruff clean.
- [ ] @bulent-1977 or @gadgetbazza re-test against real hardware to confirm reconnect rate drops to zero (and audio noise — fingers crossed — goes away).

Closes #102.