### PR TITLE
release: bump version to 2026.5.13

### DIFF
--- a/custom_components/triad_ams/manifest.json
+++ b/custom_components/triad_ams/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/bharat/homeassistant-triad-ams/issues",
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "2025.9.17"
+  "version": "2026.5.13"
 }


### PR DESCRIPTION
## Summary
Bumps `custom_components/triad_ams/manifest.json` from `2025.9.17` to `2026.5.13`.

After merge, push tag `v2026.5.13` to trigger the release workflow; then edit the auto-generated release body to the fleet 3-part format.

Primary user-facing change: the issue #102 fix (TransientDeviceError) lands in this release.