### PR TITLE
Add set_route service for direct input-to-output routing

### DIFF
--- a/custom_components/triad_ams/__init__.py
+++ b/custom_components/triad_ams/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import service
 
@@ -24,8 +25,13 @@ PLATFORMS = ["media_player"]
 
 SERVICE_TURN_ON_WITH_SOURCE = "turn_on_with_source"
 SERVICE_SET_PROTOCOL_DEBUG = "set_protocol_debug"
+SERVICE_SET_ROUTE = "set_route"
 ATTR_INPUT_ENTITY_ID = "input_entity_id"
 ATTR_PROTOCOL_DEBUG_ENABLED = "enabled"
+ATTR_OUTPUT = "output"
+ATTR_INPUT = "input"
+# Largest input/output count across all supported models (TS-AMS24).
+ABSOLUTE_MAX_CHANNELS = 24
 # Target minor version for migration
 TARGET_MINOR_VERSION = 4
 
@@ -70,6 +76,61 @@ async def async_setup(_hass: HomeAssistant, _config: ConfigType) -> bool:
         schema=vol.Schema(
             {
                 vol.Required(ATTR_PROTOCOL_DEBUG_ENABLED): cv.boolean,
+            }
+        ),
+    )
+
+    async def _handle_set_route(call: service.ServiceCall) -> None:
+        output = int(call.data[ATTR_OUTPUT])
+        input_channel = int(call.data[ATTR_INPUT])
+        entries = _hass.config_entries.async_entries(DOMAIN)
+        if not entries:
+            msg = "No Triad AMS device is configured"
+            raise HomeAssistantError(msg)
+        if len(entries) > 1:
+            msg = (
+                "triad_ams.set_route requires exactly one configured Triad AMS "
+                "device; multiple are configured"
+            )
+            raise HomeAssistantError(msg)
+        entry = entries[0]
+        output_count = int(entry.data.get("output_count", 0))
+        input_count = int(entry.data.get("input_count", 0))
+        if not 1 <= output <= output_count:
+            msg = (
+                f"output {output} is out of range for this device "
+                f"(valid range is 1..{output_count})"
+            )
+            raise HomeAssistantError(msg)
+        if not 0 <= input_channel <= input_count:
+            msg = (
+                f"input {input_channel} is out of range for this device "
+                f"(valid range is 0..{input_count}; 0 disconnects the output)"
+            )
+            raise HomeAssistantError(msg)
+        coordinator = getattr(entry, "runtime_data", None)
+        if not isinstance(coordinator, TriadCoordinatorType):
+            msg = "Triad AMS coordinator is not ready"
+            raise HomeAssistantError(msg)
+        if input_channel == 0:
+            await coordinator.disconnect_output(output)
+        else:
+            await coordinator.set_output_to_input(output, input_channel)
+
+    _hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_ROUTE,
+        _handle_set_route,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_OUTPUT): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=1, max=ABSOLUTE_MAX_CHANNELS),
+                ),
+                vol.Required(ATTR_INPUT): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=0, max=ABSOLUTE_MAX_CHANNELS),
+                ),
             }
         ),
     )

--- a/custom_components/triad_ams/services.yaml
+++ b/custom_components/triad_ams/services.yaml
@@ -23,3 +23,25 @@ set_protocol_debug:
       example: true
       selector:
         boolean:
+set_route:
+  name: "Set Route"
+  description: "Route a physical Triad AMS input to a physical Triad AMS output by index. Use input 0 to disconnect the output."
+  fields:
+    output:
+      required: true
+      example: 3
+      selector:
+        number:
+          min: 1
+          max: 24
+          step: 1
+          mode: box
+    input:
+      required: true
+      example: 5
+      selector:
+        number:
+          min: 0
+          max: 24
+          step: 1
+          mode: box

--- a/custom_components/triad_ams/translations/en.json
+++ b/custom_components/triad_ams/translations/en.json
@@ -28,6 +28,20 @@
                     "description": "The media player entity to use as the input source."
                 }
             }
+        },
+        "set_route": {
+            "name": "Set Route",
+            "description": "Route a physical Triad AMS input to a physical Triad AMS output by index. Use input 0 to disconnect the output.",
+            "fields": {
+                "output": {
+                    "name": "Output",
+                    "description": "The output channel index (1-based)."
+                },
+                "input": {
+                    "name": "Input",
+                    "description": "The input channel index (1-based), or 0 to disconnect the output."
+                }
+            }
         }
     }
 }

--- a/tests/unit/test_set_route_service.py
+++ b/tests/unit/test_set_route_service.py
@@ -1,0 +1,241 @@
+"""Unit tests for the triad_ams.set_route global service."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.triad_ams import (
+    SERVICE_SET_ROUTE,
+    async_setup,
+)
+from custom_components.triad_ams.const import DOMAIN
+from custom_components.triad_ams.coordinator import TriadCoordinator
+from tests.conftest import create_async_mock_method
+
+
+def _extract_set_route_handler(
+    hass: MagicMock,
+) -> tuple[callable, vol.Schema]:
+    """Return (handler, schema) registered for triad_ams.set_route."""
+    for call in hass.services.async_register.call_args_list:
+        args = call.args
+        kwargs = call.kwargs
+        domain = args[0] if len(args) > 0 else kwargs.get("domain")
+        service_name = args[1] if len(args) > 1 else kwargs.get("service")
+        handler = args[2] if len(args) > 2 else kwargs.get("service_func")
+        schema = (
+            kwargs.get("schema")
+            if "schema" in kwargs
+            else (args[3] if len(args) > 3 else None)
+        )
+        if domain == DOMAIN and service_name == SERVICE_SET_ROUTE:
+            return handler, schema
+    pytest.fail("set_route service was not registered")
+    return None, None  # pragma: no cover - pytest.fail raises
+
+
+def _make_service_call(data: dict) -> MagicMock:
+    """Build a MagicMock that quacks like a ServiceCall."""
+    call = MagicMock()
+    call.data = data
+    return call
+
+
+@pytest.fixture
+def hass() -> MagicMock:
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_register = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def coordinator() -> MagicMock:
+    """Create a mock coordinator that passes the isinstance() runtime check."""
+    coord = MagicMock(spec=TriadCoordinator)
+    coord.set_output_to_input = create_async_mock_method()
+    coord.disconnect_output = create_async_mock_method()
+    return coord
+
+
+@pytest.fixture
+def config_entry(coordinator: MagicMock) -> MagicMock:
+    """Create a mock config entry for an AMS8 device with the coordinator attached."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_set_route"
+    entry.data = {
+        "host": "192.168.1.100",
+        "port": 52000,
+        "model": "AMS8",
+        "input_count": 8,
+        "output_count": 8,
+    }
+    entry.options = {}
+    entry.runtime_data = coordinator
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_set_route_registered(hass: MagicMock) -> None:
+    """async_setup registers the set_route service."""
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        result = await async_setup(hass, {})
+
+    assert result is True
+    handler, schema = _extract_set_route_handler(hass)
+    assert callable(handler)
+    assert schema is not None
+
+
+@pytest.mark.asyncio
+async def test_set_route_routes_input_to_output(
+    hass: MagicMock,
+    config_entry: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    """set_route(output=3, input=5) calls coordinator.set_output_to_input(3, 5)."""
+    hass.config_entries.async_entries = MagicMock(return_value=[config_entry])
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        await async_setup(hass, {})
+
+    handler, _ = _extract_set_route_handler(hass)
+    await handler(_make_service_call({"output": 3, "input": 5}))
+
+    coordinator.set_output_to_input.assert_called_once_with(3, 5)
+    coordinator.disconnect_output.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_route_input_zero_disconnects(
+    hass: MagicMock,
+    config_entry: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    """input=0 routes through coordinator.disconnect_output, not set_output_to_input."""
+    hass.config_entries.async_entries = MagicMock(return_value=[config_entry])
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        await async_setup(hass, {})
+
+    handler, _ = _extract_set_route_handler(hass)
+    await handler(_make_service_call({"output": 4, "input": 0}))
+
+    coordinator.disconnect_output.assert_called_once_with(4)
+    coordinator.set_output_to_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_route_output_out_of_range_for_device(
+    hass: MagicMock,
+    config_entry: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    """Output above the configured device's max raises HomeAssistantError."""
+    # config_entry is AMS8 (output_count=8); request output=12.
+    hass.config_entries.async_entries = MagicMock(return_value=[config_entry])
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        await async_setup(hass, {})
+
+    handler, _ = _extract_set_route_handler(hass)
+    with pytest.raises(HomeAssistantError):
+        await handler(_make_service_call({"output": 12, "input": 1}))
+
+    coordinator.set_output_to_input.assert_not_called()
+    coordinator.disconnect_output.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_route_input_out_of_range_for_device(
+    hass: MagicMock,
+    config_entry: MagicMock,
+    coordinator: MagicMock,
+) -> None:
+    """Input above the configured device's max raises HomeAssistantError."""
+    hass.config_entries.async_entries = MagicMock(return_value=[config_entry])
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        await async_setup(hass, {})
+
+    handler, _ = _extract_set_route_handler(hass)
+    with pytest.raises(HomeAssistantError):
+        await handler(_make_service_call({"output": 1, "input": 20}))
+
+    coordinator.set_output_to_input.assert_not_called()
+    coordinator.disconnect_output.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_route_schema_rejects_negative_input(hass: MagicMock) -> None:
+    """The voluptuous schema rejects out-of-range values before the handler runs."""
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        await async_setup(hass, {})
+
+    _, schema = _extract_set_route_handler(hass)
+    with pytest.raises(vol.Invalid):
+        schema({"output": 1, "input": -1})
+    with pytest.raises(vol.Invalid):
+        schema({"output": 0, "input": 1})
+    with pytest.raises(vol.Invalid):
+        schema({"output": 25, "input": 1})
+    with pytest.raises(vol.Invalid):
+        schema({"output": 1, "input": 25})
+
+
+@pytest.mark.asyncio
+async def test_set_route_no_entries_raises(hass: MagicMock) -> None:
+    """When no Triad AMS entries are configured, the service raises."""
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        await async_setup(hass, {})
+
+    handler, _ = _extract_set_route_handler(hass)
+    with pytest.raises(HomeAssistantError):
+        await handler(_make_service_call({"output": 1, "input": 1}))
+
+
+@pytest.mark.asyncio
+async def test_set_route_multiple_entries_raises(
+    hass: MagicMock,
+    config_entry: MagicMock,
+) -> None:
+    """With more than one configured device, the service refuses to guess."""
+    other = MagicMock(spec=ConfigEntry)
+    other.entry_id = "second_entry"
+    other.data = {
+        "host": "192.168.1.101",
+        "port": 52000,
+        "model": "AMS16",
+        "input_count": 16,
+        "output_count": 16,
+    }
+    other.options = {}
+    other.runtime_data = MagicMock(spec=TriadCoordinator)
+    hass.config_entries.async_entries = MagicMock(return_value=[config_entry, other])
+    with patch(
+        "custom_components.triad_ams.service.async_register_platform_entity_service"
+    ):
+        await async_setup(hass, {})
+
+    handler, _ = _extract_set_route_handler(hass)
+    with pytest.raises(HomeAssistantError):
+        await handler(_make_service_call({"output": 1, "input": 1}))


### PR DESCRIPTION
## Summary

Adds a low-level `triad_ams.set_route` global service that routes a physical Triad AMS input index to a physical output index. This complements the existing `triad_ams.turn_on_with_source` entity service, which is the right call when both the source and destination are HA `media_player` entities; the new service covers cases where the user thinks in terms of physical ports (testing, calibration, headless setups, automations that don't want to involve a source entity).

The service goes through `TriadCoordinator`'s existing `set_output_to_input` and `disconnect_output` methods, so command pacing is preserved. Output and input are validated against the configured device model at handler time; the voluptuous schema bounds at the absolute device max (24).

Pass `input: 0` to disconnect the target output.

## Example

```yaml
service: triad_ams.set_route
data:
  output: 7
  input: 3
```

```yaml
# Disconnect output 7
service: triad_ams.set_route
data:
  output: 7
  input: 0
```

## Test plan

- [x] `triad_ams.set_route` is registered by `async_setup`
- [x] `output=3, input=5` calls `coordinator.set_output_to_input(3, 5)`
- [x] `input=0` calls `coordinator.disconnect_output(output)` instead
- [x] Output above the configured device max raises `HomeAssistantError`
- [x] Input above the configured device max raises `HomeAssistantError`
- [x] Schema rejects `output < 1`, `output > 24`, `input < 0`, `input > 24`
- [x] No configured entries raises `HomeAssistantError`
- [x] More than one configured entry raises `HomeAssistantError` (the service can't pick the right device for the user)
- [x] Full suite: 264 tests passing
- [x] `scripts/lint` clean