### PR TITLE
Declare integration_type as device in manifest

### DIFF
--- a/custom_components/triad_ams/manifest.json
+++ b/custom_components/triad_ams/manifest.json
@@ -6,6 +6,7 @@
   ],
   "config_flow": true,
   "documentation": "https://github.com/bharat/homeassistant-triad-ams",
+  "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/bharat/homeassistant-triad-ams/issues",
   "quality_scale": "bronze",


### PR DESCRIPTION
Declare `"integration_type": "device"` in `manifest.json`.

Home Assistant strongly prefers manifests to set this; new core integrations have required it since 2023, and the bronze quality scale lists it as a soft prerequisite. The right value here is `device`: the integration binds to one Triad AMS matrix via one config entry, and every zone entity shares the same device identifier in the device registry (see `media_player.py` line 363). A `hub` value would only fit if each zone surfaced as its own device, which is not the model in use.

## What changed

- `custom_components/triad_ams/manifest.json`: one new field, placed between `documentation` and `iot_class` per the conventional manifest key order.

No code changes; pytest suite still passes locally.