### PR TITLE
Document set_route and credit external Control4 integrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Quality scale: currently **Bronze** in `manifest.json`, but `custom_components/t
 │   ├── const.py                    # DOMAIN, timeouts, VOLUME_STEPS, NETWORK_EXCEPTIONS
 │   ├── diagnostics.py              # Diagnostics download (Gold quality rule)
 │   ├── repairs.py                  # Repair issue flows
-│   ├── services.yaml               # turn_on_with_source, set_protocol_debug
+│   ├── services.yaml               # turn_on_with_source, set_route, set_protocol_debug
 │   ├── strings.json / translations/en.json  # UI strings
 │   ├── icons.json                  # Icon translations
 │   ├── quality_scale.yaml          # Per-rule quality-scale status (Bronze→Platinum)
@@ -113,16 +113,23 @@ Dependabot is configured for `devcontainers`, `github-actions`, and `pip` on a d
 - **Coordinator is custom, not `DataUpdateCoordinator`.** `TriadCoordinator` (`coordinator.py`) is a single-queue, single-worker command pacer that owns the `TriadConnection`. All device I/O must go through it — do not call `TriadConnection` methods directly from entities.
 - **Config entry has migrations.** `__init__.async_migrate_entry` upgrades pre-`model` entries. The current `MINOR_VERSION` is `4`; bump `TARGET_MINOR_VERSION` and the matching constant in `config_flow.py` together when changing entry schema.
 - **`scripts/develop` boots HA against `./config/`.** That config has hardcoded Sonos IPs (`192.168.0.30..41`) and `homeassistant.components.sonos: error`. Edit your local copy as needed, but don't commit credentials/IPs that aren't already there.
-- **Two custom services** are registered in `__init__.py`: `triad_ams.turn_on_with_source` (entity service; takes another media_player as the source) and `triad_ams.set_protocol_debug` (global toggle for protocol-level logging). When changing service signatures, update both `services.yaml` and any translations.
+- **Three custom services** are registered in `__init__.py`: `triad_ams.turn_on_with_source` (entity service; takes another media_player as the source), `triad_ams.set_route` (global service; takes `output` and `input` integers, routes the input to the output, `input: 0` disconnects, raises if more than one config entry exists rather than broadcasting), and `triad_ams.set_protocol_debug` (global toggle for protocol-level logging). When changing service signatures, update `services.yaml`, the translation files (`strings.json` + `translations/en.json`), and the corresponding README section.
 - **Quality scale is tracked in `quality_scale.yaml`.** If you implement a `todo` rule, flip it to `done` in the same PR. If you regress a `done` rule, that's a release blocker.
 - **CalVer tags.** See the Releases section below — *not* SemVer. The `manifest.json` version is also CalVer and must match the tag.
 
 ## Existing docs
 
-- `README.md` — user install/config docs, what HACS renders
+- `README.md` — user install/config docs, what HACS renders. Includes a Services section that should stay in sync with `services.yaml`, and a Credits section that calls out external community integrations whose patterns this project borrows from.
 - `CONTRIBUTING.md` — short contributor guide (fork, branch, lint, PR)
 - `custom_components/triad_ams/RELEASE.md` — older maintainer release checklist; predates the auto-generated release workflow. The procedure in this file (the "Releases" section) is canonical for tag/title format; `RELEASE.md` retains useful HACS troubleshooting notes.
 - `custom_components/triad_ams/quality_scale.yaml` — authoritative status of HA quality-scale rules
+
+## External pattern references
+
+Two community HA-Control4 audio matrix integrations are tracked as inspiration sources, and credited in `README.md`. When adding a new service or entity shape, check whether either already solved it:
+
+- [Richt198/hass-control4-avm](https://github.com/Richt198/hass-control4-avm) — Control4 AVM-16S1-B. The `set_route` service shape came from here.
+- [OtisPresley/control4-mediaplayer](https://github.com/OtisPresley/control4-mediaplayer) — Control4 Matrix Amp. Useful prior art for adjacent service ideas (party mode, raw command, etc.).
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Features
   - Select device model (TS-AMS8, TS-AMS16, or TS-AMS24)
   - Choose which outputs and inputs are active
   - Optionally set a link for each input
+- Service-based routing
+  - `triad_ams.turn_on_with_source` for "route the input feeding entity X to zone Y" automations
+  - `triad_ams.set_route` for direct `(output, input)` routing without involving HA entities (use `input: 0` to disconnect)
 - Safe device handling
   - Serialized command writes
   - Trigger zone on when the first output is routed; off when the last output disconnects
@@ -65,6 +68,12 @@ Notes
 - If you later change the active lists or links in Options, the integration reloads and updates entities automatically
 - The device model selected during initial setup determines the number of available inputs and outputs
 
+Services
+--------
+- `triad_ams.turn_on_with_source` — entity service on a Triad AMS `media_player`. Takes an `input_entity_id` of another HA `media_player`; the integration looks up which Triad input is linked to that entity and routes it to the target zone. Best when both ends of the action are HA entities (the upstream source has a media_player and you want the zone to mirror it).
+- `triad_ams.set_route` — global service. Takes two integers, `output` (1..N) and `input` (0..M); routes the input to the output directly. Use `input: 0` to disconnect the output. Best for headless or calibration automations that think in terms of physical port numbers rather than HA entities. Raises if more than one Triad AMS config entry is configured (no implicit broadcast).
+- `triad_ams.set_protocol_debug` — toggles protocol-level logging across all configured entries. Field: `enabled: true|false`.
+
 Limitations
 -----------
 - Only the Triad AMS 8x8 model has been confirmed with real hardware; the 16x16 and 24x24 are supported in code but untested.
@@ -87,6 +96,8 @@ Troubleshooting
 Credits
 -------
 - Protocol reference and driver data: Tim Weiler — https://github.com/tim-weiler/triad-audio-matrix
+- The `set_route(output, input)` service shape was adopted from [Richt198/hass-control4-avm](https://github.com/Richt198/hass-control4-avm), a community Home Assistant integration for the Control4 AVM-16S1-B audio matrix. Thanks to Richt198 for the clean, orthogonal service surface.
+- [OtisPresley/control4-mediaplayer](https://github.com/OtisPresley/control4-mediaplayer) is a related community integration for the Control4 Matrix Amp. We track it for ideas worth borrowing as both projects evolve.
 - Integration author: @bharat (and contributors)
 
 License


### PR DESCRIPTION
Documents the new `triad_ams.set_route` service in `README.md` and updates `AGENTS.md` to keep it in sync.

## What changed

**README.md**
- New `Services` section listing all three custom services (`turn_on_with_source`, `set_route`, `set_protocol_debug`) with a short pointer on when to pick which.
- New bullet under `Features` so a skim of the top of the README surfaces the service-based routing path.
- New `Credits` lines for two community Home Assistant integrations whose service-shape patterns inspired recent work in this project:
  - [Richt198/hass-control4-avm](https://github.com/Richt198/hass-control4-avm) for the orthogonal `set_route(output, input)` shape we just adopted.
  - [OtisPresley/control4-mediaplayer](https://github.com/OtisPresley/control4-mediaplayer) as ongoing prior-art reference.

**AGENTS.md**
- Layout block now lists three services in the `services.yaml` comment.
- Conventions section spells out the multi-entry guard on `set_route` (raises rather than broadcasting).
- New `External pattern references` section linking the two upstream community repos so future agents know where to look for adjacent ideas.

No code changes; pytest suite still passes locally.