### PR TITLE
Pin actions/checkout and softprops/action-gh-release to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ steps.vars.outputs.tag }}
           name: Triad AMS ${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
## Summary

Adds explicit commit-SHA pins (with the version tag preserved as a trailing comment) for the two GitHub Actions used by the release workflow. The version tags themselves do not change; this is supply-chain hygiene so a force-pushed tag could not silently change the action body.

This is a subset of Renovate PR #112. That PR also wants to bump `home-assistant/actions/hassfest` from one master SHA to a newer one, and Renovate's `stability-days` check is holding the whole PR until that newer SHA passes the 14-day age window. The two pins here are independent of that and safe to land now; the hassfest bump can wait.

## Test plan

- [x] Workflow files still parse (pre-commit yaml-check and CI Hassfest/HACS validation will exercise these)
- [ ] Next release tag still produces a release through the unchanged workflow