### PR TITLE
Gate pytest-homeassistant-custom-component bumps behind dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,12 @@
       "description": "homeassistant is upgraded in lockstep with pytest-homeassistant-custom-component (see AGENTS.md fleet policy). Let helper bumps drive the HA upgrade rather than bumping homeassistant directly."
     },
     {
+      "matchDepNames": ["pytest-homeassistant-custom-component"],
+      "groupName": "homeassistant test helper",
+      "dependencyDashboardApproval": true,
+      "description": "phacc pins an exact homeassistant version, and its newest releases often require an HA prerelease. Because direct homeassistant bumps are disabled (lockstep policy), an auto-opened phacc PR fails pip install against the stable HA pin. Surface phacc bumps on the Dependency Dashboard instead; approve one (and bump homeassistant to match in the same PR) once a stable HA release with a compatible phacc exists."
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true


### PR DESCRIPTION
## Problem

`pytest-homeassistant-custom-component` (phacc) pins an exact `homeassistant==` version, and its newest releases require a Home Assistant prerelease. This repo deliberately disables direct `homeassistant` bumps (the lockstep policy in AGENTS.md, so helper bumps drive the HA upgrade), so when Renovate bumps phacc ahead of the stable HA pin, `pip install` hits `ResolutionImpossible` and the PR cannot go green until a stable HA release with a compatible phacc ships.

This is a preventive change: sibling integrations hit this and churned a red PR every cycle. triad-ams has the same exposure, so this closes it off before it starts.

## Fix

Add a packageRule that pulls phacc into its own group and gates it behind Dependency Dashboard approval. Renovate still surfaces the available phacc bump on the dashboard, but it no longer auto-opens a PR that conflicts with the stable HA pin. When a stable HA release with a compatible phacc is available, approve it from the dashboard and bump `homeassistant` to match in the same PR.

This only changes how phacc updates are surfaced. All other dependency updates keep auto-opening and auto-merging as before.

Renovate config rule is byte-identical to the validated rule merged on the sibling integrations.