### PR TITLE
Shorten aging for home-assistant/actions digest bumps to 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,14 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["home-assistant/actions"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true,
+      "platformAutomerge": true,
+      "description": "home-assistant/actions is a first-party action tracked at @master (no stable release tag), so the default 14-day aging never completes (master commits more often than that) and leaves a perpetually blocked digest PR. Apply a shorter 7-day community-vetting buffer here so digest bumps adopt automatically and stay roughly current, while still not pulling a brand-new commit. PyPI packages and tag-pinned actions keep the default 14-day aging."
     }
   ]
 }


### PR DESCRIPTION
## Problem

The GitHub Actions digest-pin PRs for `home-assistant/actions` (hassfest validation) never auto-merge (see #112). That action is tracked at `@master` (no usable release tag), and the repo-wide `minimumReleaseAge: 14 days` keeps resetting because `master` commits more often than every 14 days. Renovate perpetually re-targets the PR to a fresh digest that never ages enough, leaving a green-but-blocked PR open while main stays on an older digest.

## Fix

Add one packageRule giving `home-assistant/actions` a shorter 7-day vetting buffer (instead of 14) with auto-merge, so digest bumps adopt automatically once they have been out a week. PyPI packages and tag-pinned actions keep the 14-day aging.

Keeps the supply-chain intent (a first-party action still sits a week, gated by green CI, before adoption) while ending the perpetually-stuck PRs and keeping the action roughly current with no manual steps.