### PR TITLE
fix: downgrade TransientDeviceError log level from ERROR to DEBUG in refresh paths

### DIFF
--- a/custom_components/triad_ams/connection.py
+++ b/custom_components/triad_ams/connection.py
@@ -274,7 +274,7 @@ class TriadConnection:
             db = float(m.group(1))
             step = step_for_db(db)
             return step / VOLUME_STEPS
-        _LOGGER.error("Could not parse output volume from response: %s", resp)
+        _LOGGER.warning("Could not parse output volume from response: %s", resp)
         return 0.0
 
     async def set_output_mute(self, output_channel: int, *, mute: bool) -> None:
@@ -416,7 +416,7 @@ class TriadConnection:
         m = re.search(r"input (\d+)", resp)
         if m:
             return int(m.group(1))
-        _LOGGER.error("Could not parse output source from response: %s", resp)
+        _LOGGER.warning("Could not parse output source from response: %s", resp)
         return None
 
     async def set_trigger_zone(self, zone: int = 1, *, on: bool) -> None:

--- a/custom_components/triad_ams/models.py
+++ b/custom_components/triad_ams/models.py
@@ -195,8 +195,18 @@ class TriadAmsOutput:
             return
         try:
             self._volume = await self.coordinator.get_output_volume(self.number)
-        except (OSError, TransientDeviceError):
-            _LOGGER.exception("Failed to refresh volume for output %d", self.number)
+        except TransientDeviceError:
+            _LOGGER.debug(
+                "Transient error refreshing volume for output %d; skipping",
+                self.number,
+            )
+            return
+        except OSError:
+            _LOGGER.warning(
+                "Failed to refresh volume for output %d",
+                self.number,
+                exc_info=True,
+            )
             return
 
         # Mute is best-effort: on some AMS firmware the device returns an
@@ -210,8 +220,18 @@ class TriadAmsOutput:
 
         try:
             assigned_input = await self.coordinator.get_output_source(self.number)
-        except (OSError, TransientDeviceError):
-            _LOGGER.exception("Failed to refresh source for output %d", self.number)
+        except TransientDeviceError:
+            _LOGGER.debug(
+                "Transient error refreshing source for output %d; skipping",
+                self.number,
+            )
+            return
+        except OSError:
+            _LOGGER.warning(
+                "Failed to refresh source for output %d",
+                self.number,
+                exc_info=True,
+            )
             return
 
         _LOGGER.debug(


### PR DESCRIPTION
## Summary

Log-flood symptom from issue #102 should be cleaned up for now.

The coordinator's `_run_worker` fix in #102 correctly routes `TransientDeviceError` to DEBUG and no longer tears down the TCP socket. However, `models.refresh()` still caught `(OSError, TransientDeviceError)` together with `_LOGGER.exception()`, which always logs at **ERROR** with a full traceback, producing thousands of ERROR entries per day on systems with many active outputs (observed: 6,300+ entries per a 48 hours period on an AMS16 with 13 active outputs).

**Changes:**

- `models.py` `refresh()`: split the combined `except (OSError, TransientDeviceError)` into two clauses. 1) `TransientDeviceError` → `_LOGGER.debug(...)` and 2) `OSError` → `_LOGGER.warning(..., exc_info=True)`. Applied to both the volume and source refresh paths.
- `connection.py` `get_output_volume()` / `get_output_source()`: downgrade two `_LOGGER.error()` calls to `_LOGGER.warning()` for unparseable device responses. These are application-layer parse failures, not transport errors.

**What is unchanged:**

Write-path handlers (`set_source`, `set_volume`, `set_muted`, etc.) retain `_LOGGER.exception()` user-initiated command failures should be ERRORs.

## Test plan

- [x] All 264 existing unit + integration tests pass (`pytest tests/ -x -q`)
- [x] Lint clean (`ruff check` + `ruff format --check`)
- [x] Deployed to my HA-OS and AMS16 with 13 active outputs, zero ERROR entries from `custom_components.triad_ams.models` after full HA restart (previously 6,300+ per a 48 hours period)
- [x] Genuine transport failures (`OSError`) confirmed to still surface at WARNING level via the `except OSError: _LOGGER.warning(...)` path in `refresh()` and the unchanged `except NETWORK_EXCEPTIONS` path in the coordinator
