### PR TITLE
Bump version to 2026.7.1 for release

### DIFF
--- a/custom_components/triad_ams/manifest.json
+++ b/custom_components/triad_ams/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/bharat/homeassistant-triad-ams/issues",
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "2026.5.13"
+  "version": "2026.7.1"
 }


### PR DESCRIPTION
Version bump to 2026.7.1 ahead of tagging the release. Rolls up everything merged since v2026.5.13, including the new set_route service (#117), the TransientDeviceError log-level fix (#134), the device integration_type declaration (#118), doc updates, and routine dependency and CI maintenance.