### PR TITLE
Hold pytest in lockstep with pytest-homeassistant-custom-component

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "description": "homeassistant is upgraded in lockstep with pytest-homeassistant-custom-component (see AGENTS.md fleet policy). Let helper bumps drive the HA upgrade rather than bumping homeassistant directly."
     },
     {
+      "matchDepNames": ["pytest"],
+      "enabled": false,
+      "description": "pytest is pinned exactly by pytest-homeassistant-custom-component, so an independent pytest bump makes pip resolution impossible (observed 2026-07: pytest 9.1.x vs phacc 0.13.341 pinning pytest==9.0.3). Let phacc bumps drive the pytest upgrade, mirroring the homeassistant lockstep rule above."
+    },
+    {
       "matchDepNames": ["pytest-homeassistant-custom-component"],
       "groupName": "homeassistant test helper",
       "dependencyDashboardApproval": true,


### PR DESCRIPTION
phacc pins an exact pytest version, so renovate bumping pytest independently makes pip resolution impossible (currently pytest 9.1.x against phacc 0.13.341, which pins pytest==9.0.3). That has left the python-dependencies group PR red at pip install. This disables direct pytest bumps so phacc releases drive the pytest upgrade, mirroring the existing homeassistant lockstep rule. Once merged, renovate will rebase the group without the pytest bump and it should go green.