### PR TITLE
Do not automerge digest bumps of github actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,12 @@
     },
     {
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": false,
+      "description": "Renovate cannot compute a reliable release age for digest bumps of tag-tracked actions: it keyed aging off the old tag and auto-merged digests pointing at releases only hours old (action-gh-release v3.0.2, setup-node v6.5.0). Digest PRs stay open for a manual merge once the underlying release is 14 days old. Tag updates are unaffected; the home-assistant/actions rule below still applies last."
+    },
+    {
+      "matchManagers": ["github-actions"],
       "matchPackageNames": ["home-assistant/actions"],
       "minimumReleaseAge": "7 days",
       "automerge": true,


### PR DESCRIPTION
Renovate cannot compute a reliable release age for digest bumps of tag-tracked actions: it keys aging off the old tag, so it auto-merged digests pointing at releases only hours old (action-gh-release v3.0.2 on 2026-07-13, setup-node v6.5.0 on 2026-07-14). This disables automerge for the digest update type under the github-actions manager. Digest PRs now stay open for a manual merge once the underlying release is actually 14 days old; tag updates are unaffected, and the home-assistant/actions rule still applies last. Supersedes the action-specific rule from yesterday where present.